### PR TITLE
Add unittest.TestCase decoration from setUpClass to tearDownClass

### DIFF
--- a/libfaketime/__init__.py
+++ b/libfaketime/__init__.py
@@ -2,6 +2,7 @@ from copy import deepcopy
 import os
 import sys
 import threading
+import unittest
 
 from contextdecorator import ContextDecorator
 import dateutil.parser
@@ -109,6 +110,35 @@ class fake_time(ContextDecorator):
                 end_callback(self)
 
         return False
+
+    def __call__(self, decorable):
+        if isinstance(decorable, unittest.TestCase):
+            # If it's a TestCase, we assume you want to freeze the time for the
+            # tests, from setUpClass to tearDownClass
+            klass = decorable
+
+            # Use getattr as in Python 2.6 they are optional
+            orig_setUpClass = getattr(klass, 'setUpClass', None)
+            orig_tearDownClass = getattr(klass, 'tearDownClass', None)
+
+            @classmethod
+            def setUpClass(cls):
+                self.start()
+                if orig_setUpClass is not None:
+                    orig_setUpClass()
+
+            @classmethod
+            def tearDownClass(cls):
+                if orig_tearDownClass is not None:
+                    orig_tearDownClass()
+                self.stop()
+
+            klass.setUpClass = setUpClass
+            klass.tearDownClass = tearDownClass
+
+            return klass
+
+        return super(fake_time, self).__call__(decorable)
 
     # Freezegun compatibility.
     start = __enter__


### PR DESCRIPTION
1. _thanks_ for this library. Adding it took a whole minute off our 6 minute test suite which has some heavy `freeze_time` usage
2. This is a duplication of my recent PR to `freezegun` - https://github.com/spulec/freezegun/pull/105 - which improves the decoration of whole test cases. Unfortunately I can't run this locally since the tests don't seem easy to get running: `python setup.py test` doesn't run, and there is no `tox.ini` which most projects have. I can help add these though if you point out how you're running the tests, how `libfaketime` gets vendored in, etc.
