### PR TITLE
Add console command that prints needed envvars

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -46,3 +46,20 @@ Some brief details:
         
 
 To install: ``pip install libfaketime``.
+
+
+How to avoid re-exec
+====================
+
+Sometimes, re-exec does unexpected things. You can avoid those problems by preloading `libfaketime` yourself. The environment variables you need
+can be found by running `python-libfaketime` on the command line::
+
+    $ python-libfaketime 
+    export LD_PRELOAD="/home/allard/.virtualenvs/libfaketime/local/lib/python2.7/site-packages/libfaketime/vendor/libfaketime/src/libfaketime.so.1"
+    export FAKETIME_DID_REEXEC=true
+
+You can use them as such::
+
+    eval $(python-libfaketime)
+    nosetests  # for example
+

--- a/libfaketime/__init__.py
+++ b/libfaketime/__init__.py
@@ -57,6 +57,13 @@ def get_reload_information():
     return needs_reload, env_additions
 
 
+def main():  # pragma: nocover
+    _, _env_additions = get_reload_information()
+    for key, value in _env_additions.iteritems():
+        print 'export %s="%s"' % (key, value)
+    print 'export %s=true' % _DID_REEXEC_VAR
+
+
 def reexec_if_needed(remove_vars=True):
     needs_reload, env_additions = get_reload_information()
     if needs_reload:

--- a/setup.py
+++ b/setup.py
@@ -87,4 +87,9 @@ setup(
     include_package_data=True,
     zip_safe=False,
     cmdclass={'install': CustomInstall},
+    entry_points={
+        'console_scripts': [
+            'libfaketime = libfaketime:main',
+        ]
+    },
 )

--- a/setup.py
+++ b/setup.py
@@ -89,7 +89,7 @@ setup(
     cmdclass={'install': CustomInstall},
     entry_points={
         'console_scripts': [
-            'libfaketime = libfaketime:main',
+            'python-libfaketime = libfaketime:main',
         ]
     },
 )


### PR DESCRIPTION
When running `nosetests` or `python manage.py test` there are often left-over processes that are never reaped. As I use `watch` to run the tests every tenth of a second, that results in many, many processes :smile: 

I've traced this back to the re-exec that is performed. I would like to avoid that re-exec cleanly, but currently I have to have read the `libfaketime` source code to find out which envvars it wants. And keep the vars in sync ofcourse.

So, let's add a console script that prints out the needed envvars, like `ssh-agent` does on start. Then you can call `libfaketime` and it will output:

```bash
export LD_PRELOAD="/home/.../vendor/libfaketime/src/libfaketime.so.1"
export FAKETIME_DID_REEXEC=true
```

This can then be used at startup:

```bash
eval $(libfaketime)
nosetests
```