### PR TITLE
Deadlocks from using system level uuid1 generator

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -43,7 +43,7 @@ Some brief details:
 * accepts datetimes and strings that can be parsed by dateutil
 * not threadsafe
 * will break profiling. A workaround: use ``libfaketime.{begin, end}_callback`` to disable/enable your profiler.
-        
+
 
 To install: ``pip install libfaketime``.
 
@@ -75,3 +75,10 @@ You can use them as such::
     eval $(python-libfaketime)
     nosetests  # ...or any other code that imports libfaketime
 
+Known Issues
+============
+
+It was found that calling `uuid.uuid1()` multiple times while in a fake_time context could result in a deadlock. This situation only occured for users with
+a system level uuid1 library. In order to combat this issue, python-libfaketime temporarily disables the system level library by patching
+`_uuid_generate_time to None <https://github.com/python/cpython/blob/a1786b287598baa4a9146c9938c9a667bd98fc00/Lib/uuid.py#L565-L570>`_ while in
+the fake_time context.

--- a/libfaketime/__init__.py
+++ b/libfaketime/__init__.py
@@ -129,7 +129,7 @@ class fake_time(ContextDecorator):
 
         if self._should_patch_uuid():
             # Bug fix for uuid1 deadlocks in system level uuid libraries
-            # PR: <INSERT_PR_LINK>
+            # PR: https://github.com/simon-weber/python-libfaketime/pull/14
             self._backup_uuid_generate_time = uuid._uuid_generate_time
             uuid._uuid_generate_time = None
 


### PR DESCRIPTION
My company uses libfaketime in our large test suite. We have found that deadlocks occur when generating uuid1s from the stdlib while within a fake_time context.

I have been able to reproduce these problems consistently from in our tests and the shell. We are only able to call uuid1() 11 times for a fake time period. In the test below, I'm showing that the same time is used between two context mangers and the deadlock occurs after the 11th call.

```
In [22]: time = datetime.now()
In [23]: with fake_time(time):
    for i in range(10):
        print uuid.uuid1()
   ....:
142d8626-0caa-11e6-b453-080027cebb63
142d8627-0caa-11e6-b453-080027cebb63
142d8628-0caa-11e6-b453-080027cebb63
142d8629-0caa-11e6-b453-080027cebb63
142d862a-0caa-11e6-b453-080027cebb63
142d862b-0caa-11e6-b453-080027cebb63
142d862c-0caa-11e6-b453-080027cebb63
142d862d-0caa-11e6-b453-080027cebb63
142d862e-0caa-11e6-b453-080027cebb63
142d862f-0caa-11e6-b453-080027cebb63
In [24]: with fake_time(time):
    for i in range(10):
        print uuid.uuid1()
   ....:
142d8630-0caa-11e6-b453-080027cebb63
^Z<<--- Deadlock
[1]+  Stopped                 vshell
```

After more investigation, I found that this occurred in my VM, but not my OSX host. After looking at the uuid library, I saw that my OSX computer does not use a system level uuid generator like my VM does. [Relevant Code](https://github.com/python/cpython/blob/a1786b287598baa4a9146c9938c9a667bd98fc00/Lib/uuid.py#L565-L570) This could be a problem with the system level library used in Ubuntu 12.04.5 LTS.

The best fix we could come up with was patching `_uuid_generate_time` to `None` to disable the system level library.