### PR TITLE
Use standard library ContextDecorator on Python 3

### DIFF
--- a/libfaketime/__init__.py
+++ b/libfaketime/__init__.py
@@ -6,8 +6,12 @@ import os
 import sys
 import threading
 
-from contextdecorator import ContextDecorator
 import dateutil.parser
+
+try:
+    from contextlib import ContextDecorator
+except ImportError:
+    from contextdecorator import ContextDecorator
 
 try:
     basestring

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-contextdecorator==0.10.0
 freezegun==0.3.1
 mock==1.0.1
 nose==1.3.4

--- a/setup.py
+++ b/setup.py
@@ -70,9 +70,11 @@ setup(
     long_description=(open('README.rst').read() + '\n\n' +
                       open('CHANGELOG.rst').read()),
     install_requires=[
-        'contextdecorator',
         'python-dateutil >= 1.3, != 2.0',         # 2.0 is python3-only
     ],
+    extras_require={
+        ':python_version=="2.7"': ['contextdecorator'],
+    },
     classifiers=[
         'License :: OSI Approved :: GNU General Public License v2 (GPLv2)',
         'Development Status :: 4 - Beta',


### PR DESCRIPTION
`contextdecorator` is a backport package for Python 2, as `ContextDecorator` was added to `contextlib` on Python 3.2+.