### PR TITLE
Add timezone-aware freeze_time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ docs/_build/
 
 # PyBuilder
 target/
+
+# PyCharm
+.idea/

--- a/README.rst
+++ b/README.rst
@@ -9,6 +9,14 @@ python-libfaketime: fast date/time mocking
 
 python-libfaketime is a wrapper of `libfaketime <https://github.com/wolfcw/libfaketime>`__ for python.
 
+Some brief details:
+
+* Linux and OS X, Pythons 2 and 3
+* Microsecond resolution
+* Accepts datetimes and strings that can be parsed by dateutil
+* Not threadsafe
+* Will break profiling. A workaround: use ``libfaketime.{begin, end}_callback`` to disable/enable your profiler.
+
 Installation
 ------------
 
@@ -56,13 +64,31 @@ Here's the output of a `totally unscientific benchmark <https://github.com/simon
     6.561472 seconds
 
 
-Some brief details:
+Timezone-aware faking of time
+-----------------------------
 
-* Linux and OS X, Pythons 2 and 3
-* Microsecond resolution
-* Accepts datetimes and strings that can be parsed by dateutil
-* Not threadsafe
-* Will break profiling. A workaround: use ``libfaketime.{begin, end}_callback`` to disable/enable your profiler.
+Beware that if you want timezone-aware fake times, you must use `freeze_time` like so:
+
+.. code-block:: python
+
+    from datetime import timedelta, datetime
+    from libfaketime import reexec_if_needed, tzutc, freeze_time
+    reexec_if_needed()
+
+
+    def get_now():
+        return datetime.now(tz=tzutc())
+
+
+    @freeze_time('2014-01-01 12:00:00+1200')
+    def test_get_now1():
+        assert get_now() - datetime(2014, 1, 1, 0, 0, 0, tzinfo=tzutc()) == timedelta(0)
+
+
+    @freeze_time('2014-01-01 01:00:00')
+    def test_get_now2():
+        # freeze_time has interpreted this spec as UTC implicitly
+        assert get_now() - datetime(2014, 1, 1, 1, 0, 0, tzinfo=tzutc()) == timedelta(0)
 
 
 Use with py.test

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,6 +1,9 @@
 import os
 import subprocess
 import sys
+from unittest import TestCase
+
+import datetime
 
 import libfaketime
 
@@ -13,3 +16,14 @@ def setup_package():
     libfaketime.reexec_if_needed()
 
     print('(re-execed and compiled prior to test run)')
+
+
+class BaseFaketimeTest(TestCase):
+    def _assert_time_not_faked(self):
+        # This just makes sure that non-faked time is dynamic;
+        # I can't think of a good way to check that the non-faked time is "real".
+
+        first = datetime.datetime.now().microsecond
+        second = datetime.datetime.now().microsecond
+
+        self.assertGreater(second, first)

--- a/test/test_faketime.py
+++ b/test/test_faketime.py
@@ -6,6 +6,7 @@ from mock import patch
 
 import libfaketime
 from libfaketime import fake_time
+from test import BaseFaketimeTest
 
 
 class TestReexec(TestCase):
@@ -15,7 +16,7 @@ class TestReexec(TestCase):
         self.assertRaises(RuntimeError, libfaketime.reexec_if_needed)
 
 
-class TestFaketime(TestCase):
+class TestFaketime(BaseFaketimeTest):
     def _assert_time_not_faked(self):
         # This just makes sure that non-faked time is dynamic;
         # I can't think of a good way to check that the non-faked time is "real".

--- a/test/test_freeze_time.py
+++ b/test/test_freeze_time.py
@@ -1,0 +1,39 @@
+import datetime
+from dateutil.tz import tzutc
+from libfaketime import freeze_time
+from test import BaseFaketimeTest
+
+
+class TestFreezeTime(BaseFaketimeTest):
+    @freeze_time('2000-01-01 10:00:05')
+    def test_freeze_time_parses_easy_strings_as_utc(self):
+        self.assertEqual(datetime.datetime.now(tz=tzutc()), datetime.datetime(2000, 1, 1, 10, 0, 5, tzinfo=tzutc()))
+
+    @freeze_time('2000-01-01 10:00:05+0100')
+    def test_freeze_time_honors_given_timezone(self):
+        self.assertEqual(datetime.datetime.now(tz=tzutc()), datetime.datetime(2000, 1, 1, 9, 0, 5, tzinfo=tzutc()))
+
+    @freeze_time('march 1st, 2014 at 1:59pm')
+    def test_freeze_time_parses_tough_strings_as_utc(self):
+        self.assertEqual(datetime.datetime.now(tz=tzutc()), datetime.datetime(2014, 3, 1, 13, 59, tzinfo=tzutc()))
+
+    @freeze_time('7 Jul 2015 00:00:00 -0700')
+    def test_freeze_time_parses_tough_strings_with_timezone(self):
+        self.assertEqual(datetime.datetime.now(tz=tzutc()), datetime.datetime(2015, 7, 7, 7, 0, tzinfo=tzutc()))
+
+    @freeze_time(datetime.datetime(2014, 1, 1, microsecond=123456, tzinfo=tzutc()))
+    def test_freeze_time_has_microsecond_granularity(self):
+        self.assertEqual(datetime.datetime.now(tz=tzutc()), datetime.datetime(2014, 1, 1, microsecond=123456, tzinfo=tzutc()))
+
+    def test_nested_freeze_time(self):
+        self._assert_time_not_faked()
+
+        with freeze_time('1/1/2000'):
+            self.assertEqual(datetime.datetime.now(tz=tzutc()), datetime.datetime(2000, 1, 1, tzinfo=tzutc()))
+
+            with freeze_time('1/1/2001',):
+                self.assertEqual(datetime.datetime.now(tz=tzutc()), datetime.datetime(2001, 1, 1, tzinfo=tzutc()))
+
+            self.assertEqual(datetime.datetime.now(tz=tzutc()), datetime.datetime(2000, 1, 1, tzinfo=tzutc()))
+
+        self._assert_time_not_faked()


### PR DESCRIPTION
This PR adds a variant of `fake_time` that is timezone aware. It acts as a real drop-in replacement of `freezegun`.

closes #1