### PR TITLE
Try contextlib2 as alternative to contextdecorator on Python 2

### DIFF
--- a/libfaketime/__init__.py
+++ b/libfaketime/__init__.py
@@ -13,7 +13,11 @@ import dateutil.parser
 try:
     from contextlib import ContextDecorator
 except ImportError:
-    from contextdecorator import ContextDecorator
+    # Python 2 support
+    try:
+        from contextlib2 import ContextDecorator
+    except ImportError:
+        from contextdecorator import ContextDecorator
 
 try:
     basestring


### PR DESCRIPTION
contextlib2 is another backport of Python 3's contextlib.  Some
distributions like Fedora ship this instead of contextdecorator so check
for both.