### PR TITLE
Added a freeze_time alias

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -78,6 +78,13 @@ It's easiest to reexec from inside the pytest_configure hook:
     def pytest_configure():
         reexec_if_needed()
 
+Migration from freezegun
+------------------------
+
+.. code-block:: bash
+
+    find . -type f -name "*.py" -exec sed -i 's/freezegun/libfaketime/g' "{}" \;
+
 
 How to avoid re-exec
 --------------------

--- a/libfaketime/__init__.py
+++ b/libfaketime/__init__.py
@@ -171,3 +171,5 @@ class fake_time(ContextDecorator):
     # Freezegun compatibility.
     start = __enter__
     stop = __exit__
+
+freeze_time = fake_time

--- a/test/test_faketime.py
+++ b/test/test_faketime.py
@@ -5,7 +5,7 @@ import uuid
 from mock import patch
 
 import libfaketime
-from libfaketime import fake_time
+from libfaketime import fake_time, freeze_time
 
 
 class TestReexec(TestCase):
@@ -65,6 +65,10 @@ class TestFaketime(TestCase):
             self.assertEqual(datetime.datetime.now(), datetime.datetime(2000, 1, 1))
 
         self._assert_time_not_faked()
+
+    def test_freeze_time_alias(self):
+        with freeze_time('2000-01-01 10:00:05') as fake:
+            self.assertEqual(datetime.datetime.now(), datetime.datetime(2000, 1, 1, 10, 0, 5))
 
 
 class TestUUID1Deadlock(TestCase):


### PR DESCRIPTION
This PR simply adds a "freeze_time" alias, so compatibility with freezegun is just one import away. I think it can also help freezegun users to quickly test python-libfaketime.