### PR TITLE
Ensures a microsecond has passed

### DIFF
--- a/test/test_faketime.py
+++ b/test/test_faketime.py
@@ -1,5 +1,6 @@
 import datetime
 from unittest import TestCase
+import time
 import uuid
 
 from mock import patch
@@ -21,6 +22,7 @@ class TestFaketime(TestCase):
         # I can't think of a good way to check that the non-faked time is "real".
 
         first = datetime.datetime.now().microsecond
+        time.sleep(0.000001)
         second = datetime.datetime.now().microsecond
 
         self.assertGreater(second, first)


### PR DESCRIPTION
I have a good processor, and this assertion fails half the time. By sleeping a microsecond, we are sure that it cannot fail.
It is not usually advised to call `time.sleep` in tests, but this is a very peculiar context, and it is only about a microsecond.