### PR TITLE
Added a test to compare against freezegun mocked functions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -111,11 +111,11 @@ Contributing and testing
 
 Contributions are highly welcomed. You should compile libfaketime before running tests:
 
-```
-make -C libfaketime/vendor/libfaketime
-```
+.. code-block:: bash
 
-Then you can use `pytest` and `tox` to run the tests.
+    make -C libfaketime/vendor/libfaketime
+
+Then you can install requirements with ``pip install -r requirements.txt`` and use ``pytest`` and ``tox`` to run the tests.
 
 Known Issues
 ------------

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-freezegun==0.3.1
-mock==1.0.1
+freezegun==0.3.9
+mock==2.0.0
 pytest==3.2.1
-python-dateutil==2.4.1
+python-dateutil==2.6.1
 six==1.9.0
-wsgiref==0.1.2
+contextdecorator==0.10.0

--- a/test/test_freezegun.py
+++ b/test/test_freezegun.py
@@ -1,0 +1,36 @@
+import pytest
+import time
+import datetime
+
+from freezegun import freeze_time
+from libfaketime import fake_time
+
+# TODO
+# - Fix time.localtime
+# - Fix time.strftime
+# - Fix python2 time.time with 1970-01-01
+
+test_functions = [
+    ("datetime.datetime.now", (), {}),
+    ("datetime.datetime.utcnow", (), {}),
+    ("time.time", (), {}),
+#    ("time.localtime", (), {}),
+#    ("time.strftime", ("%Y-%m-%d %H:%M:%S %Z",), {}),
+    ("datetime.date", (), {"year": 1970, "month":1, "day":1}),
+    ("datetime.datetime", (), {"year": 1970, "month":1, "day":1}),
+]
+
+@pytest.mark.parametrize("test_function", test_functions)
+@pytest.mark.parametrize("tz_offset", [0, 12])
+@pytest.mark.parametrize("date_to_freeze", ["1970-01-01 00:00:01"]) 
+def test_compare_against_freezegun_results(test_function, tz_offset, date_to_freeze):
+    func_name, args, kwargs = test_function
+
+    with fake_time(date_to_freeze, tz_offset = tz_offset):
+        libfaketime_result = eval(func_name)(*args, **kwargs)
+
+    with freeze_time(date_to_freeze, tz_offset = tz_offset):
+        freezegun_result = eval(func_name)(*args, **kwargs)
+
+    assert freezegun_result == libfaketime_result
+

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,5 @@ envlist = py{27,34,35,36}
 [testenv]
 setenv =
     PYTHONDONTWRITEBYTECODE=1
-deps =
-    pytest
-    mock
+deps = -rrequirements.txt
 commands = pytest

--- a/tox.ini
+++ b/tox.ini
@@ -5,4 +5,4 @@ envlist = py{27,34,35,36}
 setenv =
     PYTHONDONTWRITEBYTECODE=1
 deps = -rrequirements.txt
-commands = pytest
+commands = pytest --showlocals


### PR DESCRIPTION
Freezegun [mocks](https://github.com/spulec/freezegun/blob/master/freezegun/api.py#L17) `time.time`, `time.localtime`, `time.strftime`, `datetime.datetime.now`, `datetime.datetime.utcnow`, `datetime.date` and `datetime.datetime`. This (pytest) test checks that both libraries produce the same results under the same conditions, with and without timezone offsets.

For the moment, `time.localtime` and `time.strftime` produce different results. I expect to look at this later :)

This PR comes after #33 since it uses pytest parametrization \o/, so Travis should fail until #33 is merged.