### PR TITLE
Add class decorator supporting pytest test discovery

### DIFF
--- a/libfaketime/__init__.py
+++ b/libfaketime/__init__.py
@@ -1,17 +1,16 @@
 from __future__ import print_function
 
 from copy import deepcopy
-import functools
-import unittest
-import inspect
 import datetime
+import dateutil.parser
+import functools
+import inspect
 import os
 import platform
 import sys
 import threading
+import unittest
 import uuid
-
-import dateutil.parser
 
 
 try:
@@ -176,7 +175,8 @@ class fake_time:
     start = __enter__
     stop = __exit__
 
-    # Decorator-style use support
+    # Decorator-style use support (shamelessly taken from freezegun, see
+    # https://github.com/spulec/freezegun/blob/7ad16a5579b28fc939a69cc04f0e99ba5e87b206/freezegun/api.py#L323)
 
     def __call__(self, func):
         if inspect.isclass(func):

--- a/setup.py
+++ b/setup.py
@@ -85,9 +85,6 @@ setup(
     install_requires=[
         'python-dateutil >= 1.3, != 2.0',         # 2.0 is python3-only
     ],
-    extras_require={
-        ':python_version=="2.7"': ['contextdecorator'],
-    },
     classifiers=[
         'License :: OSI Approved :: GNU General Public License v2 (GPLv2)',
         'Development Status :: 4 - Beta',

--- a/test/test_faketime.py
+++ b/test/test_faketime.py
@@ -120,3 +120,14 @@ class TestUUID1Deadlock():
             assert uuid._uuid_generate_time is None
 
         assert uuid_generate_time == uuid._uuid_generate_time
+
+
+@fake_time('2000-01-01')
+class TestClassDecorator:
+
+    def test_simple(self):
+        assert datetime.datetime(2000, 1, 1) == datetime.datetime.now()
+
+    @fake_time('2001-01-01')
+    def test_overwrite_with_func_decorator(self):
+        assert datetime.datetime(2001, 1, 1) == datetime.datetime.now()


### PR DESCRIPTION
It seems class decorator are not well handled here: a test class decorated with `fake_time` will be missed by pytest test discovery, resulting in tests being silently not executed !

You can test this by trying to run the tests provided in this PR with the current version of the lib vs with the patched one (you get 24 vs 26 tests passed...).

This PR solve the trouble by using the same class/function decorator system than in use in freezegun.