### PR TITLE
Decorated objects can access fake_time with self._faked_time

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,11 @@ Changelog
 
 `Semantic versioning <http://semver.org/>`__ is used.
 
+1.0.1
++++++
+released xxxx-xx-xx
+- decorated objects can access the fake_time object with ``self._faked_time``
+
 1.0.0
 +++++
 released 2018-06-16

--- a/libfaketime/__init__.py
+++ b/libfaketime/__init__.py
@@ -215,8 +215,6 @@ class fake_time:
             klass.setUpClass = setUpClass
             klass.tearDownClass = tearDownClass
 
-            return klass
-
         else:
 
             seen = set()
@@ -236,7 +234,9 @@ class fake_time:
                     except (AttributeError, TypeError):
                         # Sometimes we can't set this for built-in types and custom callables
                         continue
-            return klass
+
+        klass._faked_time = self
+        return klass
 
     def decorate_callable(self, func):
         def wrapper(*args, **kwargs):
@@ -250,6 +250,5 @@ class fake_time:
         wrapper.__wrapped__ = func
 
         return wrapper
-
 
 freeze_time = fake_time

--- a/test/test_faketime.py
+++ b/test/test_faketime.py
@@ -131,6 +131,8 @@ class TestClassDecorator:
 
     def test_simple(self):
         assert datetime.datetime(2000, 1, 1) == datetime.datetime.now()
+        self._faked_time.tick()
+        assert datetime.datetime(2000, 1, 1, 0, 0, 1) == datetime.datetime.now()
 
     @fake_time('2001-01-01')
     def test_overwrite_with_func_decorator(self):


### PR DESCRIPTION
Hi. I had a special case:
- I need to decorate a whole class test, and I cannot decorate its methods or use a context manager because I need the class `setUp` method to be mocked.
- I need a way to call `fake_time.tick` in the method tests.

With this PR you can do `self._faked_time` and you can access the `fake_time` object in the test methods. I was not sure about implementing the same feature for methods.

What do you think?