### PR TITLE
Fix compatibility with non-pytz tzinfo objects

### DIFF
--- a/libfaketime/__init__.py
+++ b/libfaketime/__init__.py
@@ -145,7 +145,7 @@ class fake_time:
             if datetime_spec.tzinfo:
                 if tz_offset is not None:
                     raise Exception('Cannot set tz_offset when datetime already has timezone')
-                self.timezone_str = datetime_spec.tzinfo.zone
+                self.timezone_str = datetime_spec.tzinfo.tzname(datetime_spec)
 
     def _should_fake(self):
         return not self.only_main_thread or threading.current_thread().name == 'MainThread'

--- a/test/test_tz.py
+++ b/test/test_tz.py
@@ -1,4 +1,5 @@
 import datetime
+import dateutil.tz
 import os
 
 import pytest
@@ -53,3 +54,13 @@ def test_generated_tz_is_valid(offset):
     with fake_time(now, tz_offset=offset):
         fake_tz = os.environ['TZ']
         timezone(fake_tz)  # should not raise pytzdata.exceptions.TimezoneNotFound
+
+
+def test_dateutil_tz_is_valid():
+    test_dt = datetime.datetime(2017, 1, 2, 15, 2)
+    dateutil_tzinfo = dateutil.tz.gettz('UTC')
+    dt_dateutil_tzinfo = test_dt.replace(tzinfo=dateutil_tzinfo)
+
+    # Should be compatible with a dateutil tzinfo object, not just pytz
+    with fake_time(dt_dateutil_tzinfo):
+        assert datetime.datetime.now(tz=dateutil_tzinfo) == dt_dateutil_tzinfo


### PR DESCRIPTION
My understanding of timezone code in Python is fairly limited, so please treat this as a proposal or a discussion point – it certainly needs review from someone with more understanding of the timezone ecosystem than myself.

That said, I believe what has happened here is that `python-libfaketime` is depending on `pytz` specific functionality – the `zone` attribute. From my exploration of the `pytz` and `dateutil` codebases, it _looks_ like the `tzname` method returns the same data. My understanding of the difference between `pytz` and `dateutil` is that with the former, `tzinfo` objects know about their owning `datetime`, whereas in the latter they don't (I could be wrong on this!).

This PR uses these assumptions to change `fake_time` to call `tzname(datetime_spec)` instead of using `.zone` in the case that the `datetime_spec` is a `datetime`. A test is included to prevent regressions, although a review on whether this is the best wording of this test would be appreciated.

This change fixes behaviour of `python-libfaketime` in a codebase that makes extensive use of `dateutil` and does not use `pytz`, where previously we had many test failures.