### PR TITLE
benchmark script fix

### DIFF
--- a/benchmark.py
+++ b/benchmark.py
@@ -8,14 +8,14 @@ from freezegun import freeze_time as freezegun_fake_time
 
 
 def sample(faker):
-    start = time.clock()
+    start = time.perf_counter()
 
     with faker(datetime.datetime.now()):
         datetime.datetime.now()
 
     datetime.datetime.now()
 
-    return time.clock() - start
+    return time.perf_counter() - start
 
 if __name__ == '__main__':
 


### PR DESCRIPTION
time.clock has been removed in python 3.8
https://docs.python.org/3/whatsnew/3.8.html#api-and-feature-removals