### PR TITLE
reexec_if_needed `quiet` parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ def test_datetime_now_with_offset():
     assert datetime.datetime.now() == datetime.datetime(1970, 1, 1, 12, 0, 1)
 ```
 
+### remove_vars
+
 By default, ``reexec_if_needed`` removes the ``LD_PRELOAD`` variable after the
 re-execution, to keep your environment as clean as possible. You might want it
 to stick around, for example when using parallelized tests that use subprocess
@@ -65,6 +67,15 @@ keep them around, pass ``remove_vars=False`` like:
 
 ```python
 reexec_if_needed(remove_vars=False)
+```
+
+### quiet
+
+To avoid displaying the informative text when re-executing, you can set the
+`quiet` parameter:
+
+```python
+reexec_if_needed(quiet=True)
 ```
 
 Performance

--- a/libfaketime/__init__.py
+++ b/libfaketime/__init__.py
@@ -104,14 +104,15 @@ def main():  # pragma: nocover
     print('export %s=true' % _DID_REEXEC_VAR)
 
 
-def reexec_if_needed(remove_vars=True):
+def reexec_if_needed(remove_vars=True, quiet=False):
     needs_reload, env_additions = get_reload_information()
     if needs_reload:
         new_environ = os.environ.copy()
         new_environ.update(env_additions)
         new_environ[_DID_REEXEC_VAR] = 'true'
         args = [sys.executable, [sys.executable] + sys.argv, new_environ]
-        print('re-exec with libfaketime dependencies')
+        if not quiet:
+            print('re-exec with libfaketime dependencies')
         os.execve(*args)
 
     if remove_vars:


### PR DESCRIPTION
This adds a `quiet` parameter to `reexec_if_needed` for people who want to hide the `re-exec with libfaketime dependencies` text.