### PR TITLE
timestamp files support

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,22 @@ To avoid displaying the informative text when re-executing, you can set the
 reexec_if_needed(quiet=True)
 ```
 
+### timestamp_file
+
+A common time can be shared between several execution contexts by using a file
+to store the time to mock, instead of environment variables. This is useful
+to control the time of a running process for instance. Here is a schematized
+use case:
+
+```python
+reexec_if_needed(remove_vars=False)
+
+with fake_time("1970-01-01 00:00:00", timestamp_file="/tmp/timestamp"):
+    subprocess.run("/some/server/process")
+
+with fake_time("2000-01-01 00:00:00", timestamp_file="/tmp/timestamp"):
+    assert request_the_server_process_date() == "2000-01-01 00:00:00"
+
 Performance
 -----------
 

--- a/test/test_faketime.py
+++ b/test/test_faketime.py
@@ -87,6 +87,21 @@ class TestFaketime():
     def test_monotonic_not_mocked(self):
         assert os.environ['DONT_FAKE_MONOTONIC'] == '1'
 
+    def test_timestmap_file(self, tmpdir):
+        file_path = str(tmpdir / "faketime.rc")
+
+        with fake_time('2000-01-01 10:00:05', timestamp_file=file_path) as fake:
+            assert datetime.datetime(2000, 1, 1, 10, 0, 5) == datetime.datetime.now()
+            with open(file_path) as fd:
+                assert fd.read() == "2000-01-01 10:00:05.000000"
+
+            fake.tick(delta=datetime.timedelta(hours=1))
+            assert datetime.datetime(2000, 1, 1, 11, 0, 5) == datetime.datetime.now()
+            with open(file_path) as fd:
+                assert fd.read() == "2000-01-01 11:00:05.000000"
+
+        with fake_time(timestamp_file=file_path):
+            assert datetime.datetime(2000, 1, 1, 11, 0, 5) == datetime.datetime.now()
 
 class TestUUID1Deadlock():
 


### PR DESCRIPTION
This PR depends on #75.
Il also fixes #70.

It adds a new parameter `timestamp_file` to `fake_time`. When passed, the date is written in this file, and the `FAKETIME_TIMESTAMP_FILE` environment variable is used instead of `FAKETIME`.

It also allows to not pass `datetime_spec` to `fake_time` when `timestamp_file` is passed, so the time value is simply read from the file.