### PR TITLE
pre-commit update

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,19 +1,15 @@
 ---
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: 'v0.4.3'
+    rev: 'v0.8.5'
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
       - id: ruff-format
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v5.0.0
     hooks:
       - id: fix-byte-order-marker
       - id: trailing-whitespace
       - id: end-of-file-fixer
       - id: check-toml
-  - repo: https://github.com/PyCQA/docformatter
-    rev: v1.7.5
-    hooks:
-      - id: docformatter

--- a/libfaketime/__init__.py
+++ b/libfaketime/__init__.py
@@ -84,7 +84,6 @@ def get_reload_information():
 
 def main():  # pragma: nocover
     """Print the necessary environment to stdout."""
-
     _, _env_additions = get_reload_information()
     for key, value in _env_additions.items():
         print(f'export {key}="{value}"')
@@ -109,12 +108,12 @@ def reexec_if_needed(remove_vars=True, quiet=False):
 
 
 def begin_callback(instance):
-    """Called just before faking the time."""
+    """Execute custom code just before faking the time."""
     pass
 
 
 def end_callback(instance):
-    """Called just after finished faking the time."""
+    """Execute custom code after finished faking the time."""
     pass
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,26 @@
 [tool.ruff.lint]
 select = [
+    "D", # pydocstyle
     "E", # pycodestyle
     "F", # pyflakes
     "I", # isort
     "UP", # pyupgrade
 ]
+ignore = [
+    "D100", # public module
+    "D101", # public class
+    "D102", # public method
+    "D103", # public function
+    "D104", # public package
+    "D105", # magic method
+    "D106", # nested class
+    "D107", # public init
+    "D203", # no-blank-line-before-class
+    "D213", # multi-line-summary-second-line
+]
 
 [tool.ruff.lint.isort]
 force-single-line = true
 
-[too.ruff.format]
+[tool.ruff.format]
 docstring-code-format = true

--- a/test/test_faketime.py
+++ b/test/test_faketime.py
@@ -110,8 +110,10 @@ class TestFaketime:
 class TestUUID1Deadlock:
     @fake_time(datetime.datetime.now())
     def test_uuid1_does_not_deadlock(self):
-        """This test will deadlock if we fail to patch a system level uuid
-        library."""
+        """Check the compatibility of uuid1.
+
+        This test will deadlock if we fail to patch a system level uuid library.
+        """
         for i in range(100):
             uuid.uuid1()
 

--- a/test/test_tz.py
+++ b/test/test_tz.py
@@ -9,7 +9,10 @@ from libfaketime import fake_time
 
 
 def test_timezone_is_restored_after_context_manager_usage():
-    """https://github.com/simon-weber/python-libfaketime/issues/43"""
+    """Check that timezones are restored when faketime context manager are closed.
+
+    https://github.com/simon-weber/python-libfaketime/issues/43
+    """
     now1 = datetime.datetime.now()
     utcnow1 = datetime.datetime.utcnow()
 
@@ -37,8 +40,7 @@ def test_tzinfo_is_normalized():
 
 
 def test_block_setting_of_conflicting_tz_info():
-    """Cannot pass in tz_offset when the timestamp already carries a
-    timezone."""
+    """Cannot pass in tz_offset when the timestamp already carries a timezone."""
     with pytest.raises(Exception) as exc_info:
         timezone_to_test_with = timezone("America/Havana")
         time_to_freeze = timezone_to_test_with.localize(
@@ -55,7 +57,10 @@ def test_block_setting_of_conflicting_tz_info():
 
 @pytest.mark.parametrize("offset", range(-2, 3))
 def test_generated_tz_is_valid(offset):
-    """https://github.com/simon-weber/python-libfaketime/issues/46"""
+    """Check that generated timezones are valid.
+
+    https://github.com/simon-weber/python-libfaketime/issues/46
+    """
     now = datetime.datetime.now()
 
     with fake_time(now, tz_offset=offset):


### PR DESCRIPTION
As docformatter pre-commit hook is not compatible with pre-commit 4, it is replaced by ruff `pydocstyle` rules.

pydocstyle raised a few minor warning about docstring, that's why I subtlety edited them.